### PR TITLE
Add pytest async tests with coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,11 @@ mkdocs serve -a 127.0.0.1:8001
 ```
 
 2. Abra `http://127.0.0.1:8001` no navegador para visualizar a documentação.
+
+## Testes
+
+Execute a suíte de testes com cobertura usando:
+```bash
+pytest --cov=car_api --cov-report=term --cov-report=html
+```
+O relatório HTML será gerado na pasta `htmlcov`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,3 +93,11 @@ mkdocs serve -a 127.0.0.1:8001
 ```
 
 2. Abra `http://127.0.0.1:8001` no navegador para visualizar a documentação.
+
+## Testes
+
+Execute a suíte de testes com cobertura de código:
+```bash
+pytest --cov=car_api --cov-report=term --cov-report=html
+```
+O resultado em HTML ficará disponível em `htmlcov`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,3 +52,7 @@ uvloop==0.21.0
 watchdog==6.0.0
 watchfiles==1.0.5
 websockets==15.0.1
+
+pytest==8.2.1
+pytest-asyncio==0.23.6
+pytest-cov==5.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,44 @@
+import httpx
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from car_api.app import app
+from car_api.database import get_session
+from car_api.models import Base
+from car_api.settings import Settings
+
+DATABASE_URL = Settings().DATABASE_URL
+
+
+@pytest_asyncio.fixture(scope='function')
+async def engine():
+    engine = create_async_engine(DATABASE_URL)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield engine
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def session(engine):
+    async_session = sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+    async with async_session() as session:
+        yield session
+
+
+@pytest_asyncio.fixture
+async def client(session):
+    async def override_get_session():
+        yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+    transport = httpx.ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url='http://testserver'
+    ) as client:
+        yield client
+    app.dependency_overrides.clear()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,24 @@
+from builtins import anext
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+
+from car_api import database
+from car_api.models import Base
+from car_api.settings import Settings
+
+
+@pytest.mark.asyncio
+async def test_get_session(monkeypatch):
+    engine = create_async_engine(Settings().DATABASE_URL)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    monkeypatch.setattr(database, 'engine', engine)
+    gen = database.get_session()
+    session = await anext(gen)
+
+    assert isinstance(session, AsyncSession)
+
+    await gen.aclose()
+    await engine.dispose()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,21 @@
+import pytest
+
+from car_api.models import Car
+
+
+@pytest.mark.asyncio
+async def test_create_car(session):
+    car = Car(
+        brand="Ford",
+        model="Fiesta",
+        color="Blue",
+        factory_year=2020,
+        model_year=2021,
+        description="desc",
+    )
+    session.add(car)
+    await session.commit()
+    await session.refresh(car)
+
+    assert car.id is not None
+    assert car.brand == "Ford"

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -1,0 +1,68 @@
+import pytest
+from fastapi import HTTPException
+
+from car_api.routers import (
+    create_car,
+    delete_car,
+    get_car,
+    list_cars,
+    patch_car,
+    update_car,
+)
+from car_api.schemas import CarPartialUpdate, CarSchema
+
+
+@pytest.mark.asyncio
+async def test_crud_flow(session):
+    schema = CarSchema(
+        brand='Ford',
+        model='Fiesta',
+        color='Blue',
+        factory_year=2020,
+        model_year=2021,
+        description='desc',
+    )
+
+    car = await create_car(schema, session)
+    car_id = car.id
+
+    result = await get_car(car_id, session)
+    assert result.model == 'Fiesta'
+
+    cars = await list_cars(session)
+    assert len(cars['cars']) == 1
+
+    schema.model = 'Focus'
+    updated = await update_car(car_id, schema, session)
+    assert updated.model == 'Focus'
+
+    partial = CarPartialUpdate(color='Red')
+    patched = await patch_car(car_id, partial, session)
+    assert patched.color == 'Red'
+
+    await delete_car(car_id, session)
+    cars = await list_cars(session)
+    assert cars['cars'] == []
+
+
+@pytest.mark.asyncio
+async def test_car_not_found_errors(session):
+    schema = CarSchema(
+        brand='Ford',
+        model='Fiesta',
+        color='Blue',
+        factory_year=2020,
+        model_year=2021,
+        description='desc',
+    )
+    with pytest.raises(HTTPException):
+        await get_car(999, session)
+
+    with pytest.raises(HTTPException):
+        await update_car(999, schema, session)
+
+    with pytest.raises(HTTPException):
+        await patch_car(999, CarPartialUpdate(model='X'), session)
+
+    with pytest.raises(HTTPException):
+        await delete_car(999, session)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,46 @@
+from car_api.schemas import CarList, CarPartialUpdate, CarPublic, CarSchema
+
+
+def test_car_schema_valid():
+    car = CarSchema(
+        brand='Ford',
+        model='Fiesta',
+        color='Blue',
+        factory_year=2020,
+        model_year=2021,
+        description='desc',
+    )
+    assert car.model == 'Fiesta'
+
+
+def test_car_partial_update_optional():
+    data = CarPartialUpdate(model='Focus')
+    assert data.model == 'Focus'
+    assert data.brand is None
+
+
+def test_car_public():
+    car = CarPublic(
+        id=1,
+        brand='Ford',
+        model='Fiesta',
+        color='Blue',
+        factory_year=2020,
+        model_year=2021,
+        description='desc',
+    )
+    assert car.id == 1
+
+
+def test_car_list():
+    car = CarPublic(
+        id=1,
+        brand='Ford',
+        model='Fiesta',
+        color='Blue',
+        factory_year=2020,
+        model_year=2021,
+        description='desc',
+    )
+    cars = CarList(cars=[car])
+    assert cars.cars[0].brand == 'Ford'


### PR DESCRIPTION
## Summary
- add pytest, pytest-asyncio and pytest-cov dependencies
- provide fixtures for async DB session and FastAPI client
- create unit tests for models, routers, schemas and database
- document how to run the tests with coverage
- use project Settings for test DB url
- drop hard coded connections in test helpers

## Testing
- `PYTHONPATH=. DATABASE_URL=sqlite+aiosqlite:///:memory: ruff check`
- `PYTHONPATH=. DATABASE_URL=sqlite+aiosqlite:///:memory: pytest -q`
- `PYTHONPATH=. DATABASE_URL=sqlite+aiosqlite:///:memory: pytest --cov=car_api --cov-report=term --cov-report=html -q`


------
https://chatgpt.com/codex/tasks/task_e_684c38baa014832595e3acb3f081bc02